### PR TITLE
Fix undeclared warnings for UndefinedObject class while loading changes via Monticello

### DIFF
--- a/.squot
+++ b/.squot
@@ -1,6 +1,6 @@
 OrderedDictionary {
-	'src\/ContextS2-Core.package' : #SquotCypressCodeSerializer,
-	'src\/ContextS2-Tests.package' : #SquotCypressCodeSerializer,
-	'src\/BoBreakout.package' : #SquotCypressCodeSerializer,
-	'src\/BaselineOfContextS.package' : #SquotCypressCodeSerializer
+	'src/ContextS2-Core.package' : #SquotCypressCodeSerializer,
+	'src/ContextS2-Tests.package' : #SquotCypressCodeSerializer,
+	'src/BoBreakout.package' : #SquotCypressCodeSerializer,
+	'src/BaselineOfContextS.package' : #SquotCypressCodeSerializer
 }

--- a/src/ContextS2-Core.package/PseudoClass.extension/instance/addMethodChange..st
+++ b/src/ContextS2-Core.package/PseudoClass.extension/instance/addMethodChange..st
@@ -1,10 +1,11 @@
 *contexts2-core-methods-override
 addMethodChange: aChangeRecord
+	 
 	"override this to re-add the layers to the selector, so we can load multiple partial methods"
 	| selector |
 	selector := self newParser parseSelector: aChangeRecord string.
 	"--- BEGIN CONTEXTS OVERRIDE ---"
-	((((self newParser parse: aChangeRecord string class: UndefinedObject)
+	((((self newParser parse: aChangeRecord string class: (aChangeRecord methodClass ifNil: [Object]))
 		properties pragmas
 		select: [:p | p keyword = #layer:])
 		gather: [:p | p arguments]) collect: [:a | a asString])

--- a/src/ContextS2-Core.package/PseudoClass.extension/methodProperties.json
+++ b/src/ContextS2-Core.package/PseudoClass.extension/methodProperties.json
@@ -2,4 +2,4 @@
 	"class" : {
 		 },
 	"instance" : {
-		"addMethodChange:" : "pre 10/30/2019 16:18" } }
+		"addMethodChange:" : "ct 9/4/2021 01:10" } }


### PR DESCRIPTION
In many cases, the class that the current change record belongs to is already available, which is when we do not need to generate additional warnings from the parser.